### PR TITLE
Change a package name for baseOn value

### DIFF
--- a/net.java.amateras.db/schema/dialects.exsd
+++ b/net.java.amateras.db/schema/dialects.exsd
@@ -57,7 +57,7 @@
                   
                </documentation>
                <appInfo>
-                  <meta.attribute kind="java" basedOn="net.java.amateras.db.view.dialect.IDialect"/>
+                  <meta.attribute kind="java" basedOn="net.java.amateras.db.dialect.IDialect"/>
                </appInfo>
             </annotation>
          </attribute>


### PR DESCRIPTION
* Hi, Thanks for maintaing a good program.
* I think Class name needs to be changed in extension point definition file. (net.java.amateras.db.view.dialect.IDialect class file does not exist.)
* Thus, I changed from **net.java.amateras.db.view.dialect.IDialect** to **net.java.amateras.db.dialect.IDialect**
* It's a trivial. but, please check it.