### PR TITLE
Disappears Scroll bar in the list of tables when Clicking "Load tables" button in the step of "Import tables from database" on [New database Diagram] WizardPage

### DIFF
--- a/net.java.amateras.db/src/net/java/amateras/db/wizard/NewDiagramWizardPage2.java
+++ b/net.java.amateras.db/src/net/java/amateras/db/wizard/NewDiagramWizardPage2.java
@@ -194,7 +194,7 @@ public class NewDiagramWizardPage2 extends WizardPage {
 		//----------------
 		UIUtils.createLabel(container, DBPlugin.getResourceString("wizard.new.import.tables"));
 		list = new List(container, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL);
-		list.setLayoutData(UIUtils.createGridData(3));
+		list.setLayoutData(UIUtils.createGridData(3, GridData.FILL_BOTH));
 		
 		//----------------
 		autoConvert = new Button(container, SWT.CHECK);


### PR DESCRIPTION
**Description**
--
Disappears Scroll bar in the list of tables and "Convert physical name to logical name" button when Clicking "Load tables" button (If a lots of tables are loaded) in the step of "Import tables from database" on [New database Diagram] WizardPage. So, Users may not be available to find tables to select.

Refer to screenshots as below, please.

**Screenshots (AS-IS)**
-

* Step 1. Click "Load tables" button
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/5a34421e-a734-4675-8354-d7572b027700)

* Step 2. Click "Maximize" button
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/b88c7abb-1bc0-4bf6-9486-f9c0d6b60601)

* Step 3. Click "Maximize" button again
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/59d93759-e686-45f8-a620-08dc22cb482a)
You'll see that scroll bar and "Convert physical name to logical name" button are disappeared

**Screenshots (TO-BE)**
-

* Step 1. Click "Load tables" button
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/18dd4354-65ab-4e1a-a94b-19ec40e545ce)

* Step 2. Click "Maximize" button
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/61ffec50-bf74-40d3-bfd9-a10f1d695947)

* Step 3. Click "Maximize" button again
![image](https://github.com/takezoe/amateras-modeler/assets/3443879/18dd4354-65ab-4e1a-a94b-19ec40e545ce)



