### PR TITLE
Replace deprecated class LocalSelectionTransfer

### DIFF
--- a/net.java.amateras.umleditor.java/src/net/java/amateras/uml/dnd/java/ClassDiagramDropTargetListenerFactory.java
+++ b/net.java.amateras.umleditor.java/src/net/java/amateras/uml/dnd/java/ClassDiagramDropTargetListenerFactory.java
@@ -7,8 +7,8 @@ package net.java.amateras.uml.dnd.java;
 import net.java.amateras.uml.dnd.UMLDropTargetListenerFactory;
 
 import org.eclipse.gef.EditPartViewer;
+import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.util.TransferDropTargetListener;
-import org.eclipse.ui.views.navigator.LocalSelectionTransfer;
 
 /**
  * @author Takahiro Shida.
@@ -22,7 +22,7 @@ public class ClassDiagramDropTargetListenerFactory extends
 	 */
 	public TransferDropTargetListener getDropTargetListener(
 			EditPartViewer viewer) {
-		return new ClassDiagramDropTargetListener(viewer, LocalSelectionTransfer.getInstance());
+		return new ClassDiagramDropTargetListener(viewer, LocalSelectionTransfer.getTransfer());
 	}
 
 	public boolean accept(String key) {

--- a/net.java.amateras.umleditor.java/src/net/java/amateras/uml/dnd/java/SequenceDiagramDropTargetListenerFactory.java
+++ b/net.java.amateras.umleditor.java/src/net/java/amateras/uml/dnd/java/SequenceDiagramDropTargetListenerFactory.java
@@ -6,8 +6,8 @@ package net.java.amateras.uml.dnd.java;
 import net.java.amateras.uml.dnd.UMLDropTargetListenerFactory;
 
 import org.eclipse.gef.EditPartViewer;
+import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.util.TransferDropTargetListener;
-import org.eclipse.ui.views.navigator.LocalSelectionTransfer;
 
 /**
  * @author shida
@@ -21,7 +21,7 @@ public class SequenceDiagramDropTargetListenerFactory extends
 	 */
 	public TransferDropTargetListener getDropTargetListener(
 			EditPartViewer viewer) {
-		return new SequenceDiagramDropTargetListener(viewer, LocalSelectionTransfer.getInstance());
+		return new SequenceDiagramDropTargetListener(viewer, LocalSelectionTransfer.getTransfer());
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
Fixes https://github.com/cypher256/pleiades.io/issues/150

The deprecated class org.eclipse.ui.views.navigator.LocalSelectionTransfer has been removed at Eclipse 2023-06.
Replaced with org.eclipse.jface.util.LocalSelectionTransfer (since Eclipse 3.5).
Thank you.